### PR TITLE
table: don't render jobs that don't exist

### DIFF
--- a/src/components/cylc/Job.vue
+++ b/src/components/cylc/Job.vue
@@ -94,7 +94,7 @@ const Job = (props, context) => {
 Job.props = {
   status: {
     type: String,
-    required: false,
+    required: true,
   },
   previousState: {
     type: String,

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -56,15 +56,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           >
             <template v-slot:item.task.name="{ item }">
               <div class="d-flex align-content-center flex-nowrap">
-                <div class="mr-1">
+                <div style="width: 2em;">
                   <Task
                     v-cylc-object="item.value.task"
                     :task="item.value.task.node"
                     :startTime="item.value.latestJob?.node?.startedTime"
                   />
                 </div>
-                <div class="mr-2">
+                <div style="width: 2em;">
                   <Job
+                    v-if="item.value.latestJob"
                     v-cylc-object="item.value.latestJob"
                     :status="item.value.latestJob?.node?.state"
                     :previous-state="item.value.previousJob?.node?.state"
@@ -102,12 +103,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               >
                 <td :colspan="3">
                   <div class="d-flex align-content-center flex-nowrap">
-                    <div class="d-flex">
+                    <div class="d-flex" style="margin-left: 2em;">
                       <Job
                         v-cylc-object="job"
                         :key="`${job.id}-summary-${index}`"
                         :status="job.node.state"
-                        style="margin-left: 1.3em;"
                       />
                       <span class="ml-2">#{{ job.node.submitNum }}</span>
                     </div>


### PR DESCRIPTION
Avoid creating a Job component when there is no job to display.