### PR TITLE
flatten workflows recursively

### DIFF
--- a/src/components/cylc/gscan/sort.js
+++ b/src/components/cylc/gscan/sort.js
@@ -99,6 +99,15 @@ export function flattenWorkflowParts (node) {
       name: child.id.substring(node.parent.length + 1), // (parent ID doesn't include slash so add 1)
       parent: node.parent,
     })
+  } else if (node.type === 'workflow-part' && node.children.length > 0) {
+    const ret = {
+      ...node,
+      children: []
+    }
+    for (const child of node.children) {
+      ret.children.push(flattenWorkflowParts(child))
+    }
+    return ret
   }
   return node
 }


### PR DESCRIPTION
The tree flattening should work recursively i.e this should flatten:

* a
  * a1

And so should:

* a
  * a1
    * a11

There's something approximating a spec back in one of the earlier PRs: https://github.com/cylc/cylc-ui/pull/1037#issuecomment-1315119550