### PR TITLE
Analysis view: remember sort & pagination state on navigation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,16 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
+## __cylc-ui-2.5.0 (<span actions:bind='release-date'>Upcoming</span>)__
+
+### Enhancements
+
+[#1744](https://github.com/cylc/cylc-ui/pull/1744),
+[#1717](https://github.com/cylc/cylc-ui/pull/1717) -
+
+Certain view options are now remembered & restored when navigating between workflows.
+
+-------------------------------------------------------------------------------
 ## __cylc-ui-2.4.0 (<span actions:bind='release-date'>Released 2024-04-02</span>)__
 
 ### Enhancements

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,6 @@ ones in. -->
 
 [#1744](https://github.com/cylc/cylc-ui/pull/1744),
 [#1717](https://github.com/cylc/cylc-ui/pull/1717) -
-
 Certain view options are now remembered & restored when navigating between workflows.
 
 -------------------------------------------------------------------------------

--- a/src/components/cylc/analysis/AnalysisTable.vue
+++ b/src/components/cylc/analysis/AnalysisTable.vue
@@ -31,8 +31,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <v-data-table
           :headers="shownHeaders"
           :items="tasks"
-          :sort-by="sortBy"
+          v-model:sort-by="sortBy"
           density="compact"
+          v-model:page="page"
           v-model:items-per-page="itemsPerPage"
         >
           <!-- Use custom format for values in columns that have a specified formatter: -->
@@ -56,9 +57,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <script>
 import { upperFirst } from 'lodash'
 import { formatDuration } from '@/utils/tasks'
+import {
+  initialOptions,
+  updateInitialOptionsEvent,
+  useInitialOptions
+} from '@/utils/initialOptions'
 
 export default {
   name: 'AnalysisTableComponent',
+
+  emits: [updateInitialOptionsEvent],
 
   props: {
     tasks: {
@@ -68,15 +76,38 @@ export default {
     timingOption: {
       type: String,
       required: true
+    },
+    initialOptions,
+  },
+
+  setup (props, { emit }) {
+    /**
+     * The number of tasks displayed per page.
+     * @type {import('vue').Ref<number>}
+     */
+    const itemsPerPage = useInitialOptions('tasksFilter', { props, emit }, 50)
+
+    /**
+     * The 'sort by' state.
+     * @type {import('vue').Ref<array>}
+     */
+    const sortBy = useInitialOptions('sortBy', { props, emit }, [{ key: 'name', order: 'asc' }])
+
+    /**
+     * The page number state.
+     * @type {import('vue').Ref<number>}
+     */
+    const page = useInitialOptions('page', { props, emit }, 1)
+
+    return {
+      itemsPerPage,
+      sortBy,
+      page
     }
   },
 
   data () {
     return {
-      itemsPerPage: 50,
-      sortBy: [
-        { key: 'name', order: 'asc' }
-      ],
       headers: [
         {
           title: 'Task',

--- a/src/components/cylc/analysis/BoxPlot.vue
+++ b/src/components/cylc/analysis/BoxPlot.vue
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <template>
   <Teleport
     v-if="sortInputTeleportTarget"
-    :to="sortInputTeleportTarget"
+    :to="`#${sortInputTeleportTarget}`"
   >
     <div class="d-flex flex-grow-1 col-gap-1">
       <v-select
@@ -91,7 +91,7 @@ export default {
       type: Boolean,
       default: true,
     },
-    /** Where to teleport the sorting input (or don't render if null) */
+    /** ID of element to teleport the sorting input (or don't render if null) */
     sortInputTeleportTarget: {
       type: String,
       default: null,

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -21,9 +21,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     :items="tasks"
     item-value="task.id"
     multi-sort
-    :sort-by="sortBy"
+    v-model:sort-by="sortBy"
     show-expand
     density="compact"
+    v-model:page="page"
     v-model:items-per-page="itemsPerPage"
   >
     <template v-slot:item.task.name="{ item }">
@@ -100,7 +101,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script>
-import { ref } from 'vue'
 import Task from '@/components/cylc/Task.vue'
 import Job from '@/components/cylc/Job.vue'
 import { mdiChevronDown } from '@mdi/js'
@@ -108,15 +108,23 @@ import { DEFAULT_COMPARATOR } from '@/components/cylc/common/sort'
 import { datetimeComparator } from '@/components/cylc/table/sort'
 import { dtMean } from '@/utils/tasks'
 import { useCyclePointsOrderDesc } from '@/composables/localStorage'
+import {
+  initialOptions,
+  updateInitialOptionsEvent,
+  useInitialOptions
+} from '@/utils/initialOptions'
 
 export default {
   name: 'TableComponent',
+
+  emits: [updateInitialOptionsEvent],
 
   props: {
     tasks: {
       type: Array,
       required: true
-    }
+    },
+    initialOptions,
   },
 
   components: {
@@ -124,21 +132,30 @@ export default {
     Job,
   },
 
-  setup () {
+  setup (props, { emit }) {
     const cyclePointsOrderDesc = useCyclePointsOrderDesc()
-    return {
-      itemsPerPage: ref(50),
-      sortBy: ref([
+
+    const sortBy = useInitialOptions(
+      'sortBy',
+      { props, emit },
+      [
         {
           key: 'task.tokens.cycle',
           order: cyclePointsOrderDesc.value ? 'desc' : 'asc'
         },
-      ]),
-    }
-  },
+      ]
+    )
 
-  methods: {
-    dtMean
+    const page = useInitialOptions('page', { props, emit }, 1)
+
+    const itemsPerPage = useInitialOptions('itemsPerPage', { props, emit }, 50)
+
+    return {
+      dtMean,
+      itemsPerPage,
+      page,
+      sortBy,
+    }
   },
 
   headers: [

--- a/src/views/Analysis.vue
+++ b/src/views/Analysis.vue
@@ -125,6 +125,10 @@ import {
 import gql from 'graphql-tag'
 import { getPageTitle } from '@/utils/index'
 import graphqlMixin from '@/mixins/graphql'
+import {
+  initialOptions,
+  useInitialOptions
+} from '@/utils/initialOptions'
 import AnalysisTable from '@/components/cylc/analysis/AnalysisTable.vue'
 import BoxPlot from '@/components/cylc/analysis/BoxPlot.vue'
 import {
@@ -227,18 +231,33 @@ export default {
     this.historicalQuery()
   },
 
+  props: { initialOptions },
+
+  setup (props, { emit }) {
+    /**
+     * The task name, timing option and platform filter state.
+     * @type {import('vue').Ref<object>}
+     */
+    const tasksFilter = useInitialOptions('tasksFilter', { props, emit }, { name: '', timingOption: 'totalTimes', platformOption: -1 })
+
+    /**
+     * If true the anaysis will be shown in table format
+     * @type {import('vue').Ref<boolean>}
+     */
+    const table = useInitialOptions('tasksFilter', { props, emit }, true)
+
+    return {
+      tasksFilter,
+      table
+    }
+  },
+
   data () {
     const tasks = []
     return {
       callback: new AnalysisCallback(tasks),
       /** Object containing all of the tasks added by the callback */
       tasks,
-      tasksFilter: {
-        name: '',
-        timingOption: 'totalTimes',
-        platformOption: -1,
-      },
-      table: true,
     }
   },
 

--- a/src/views/Analysis.vue
+++ b/src/views/Analysis.vue
@@ -103,12 +103,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </v-defaults-provider>
       </div>
       <AnalysisTable
-        v-if="table"
+        v-if="table && filteredTasks.length"
         :tasks="filteredTasks"
         :timing-option="timingOption"
       />
       <BoxPlot
-        v-else
+        v-if="!table && filteredTasks.length"
         :tasks="filteredTasks"
         :timing-option="timingOption"
         sort-input-teleport-target="#analysis-toolbar"
@@ -244,7 +244,7 @@ export default {
      * If true the anaysis will be shown in table format
      * @type {import('vue').Ref<boolean>}
      */
-    const table = useInitialOptions('tasksFilter', { props, emit }, true)
+    const table = useInitialOptions('table', { props, emit }, true)
 
     return {
       tasksFilter,

--- a/src/views/Analysis.vue
+++ b/src/views/Analysis.vue
@@ -107,6 +107,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         v-if="table"
         :tasks="filteredTasks"
         :timing-option="timingOption"
+        v-model:initial-options="dataTableOptions"
       />
       <BoxPlot
         v-else
@@ -129,6 +130,7 @@ import { getPageTitle } from '@/utils/index'
 import graphqlMixin from '@/mixins/graphql'
 import {
   initialOptions,
+  updateInitialOptionsEvent,
   useInitialOptions
 } from '@/utils/initialOptions'
 import AnalysisTable from '@/components/cylc/analysis/AnalysisTable.vue'
@@ -233,6 +235,8 @@ export default {
     this.historicalQuery()
   },
 
+  emits: [updateInitialOptionsEvent],
+
   props: { initialOptions },
 
   setup (props, { emit }) {
@@ -251,10 +255,17 @@ export default {
     /** @type {import('vue').Ref<HTMLElement>} template ref */
     const toolbar = ref(null)
 
+    /**
+     * The Vuetify data table options (sortBy, page etc).
+     * @type {import('vue').Ref<object>}
+     */
+    const dataTableOptions = useInitialOptions('dataTableOptions', { props, emit })
+
     return {
       tasksFilter,
       table,
       toolbar,
+      dataTableOptions
     }
   },
 

--- a/src/views/Analysis.vue
+++ b/src/views/Analysis.vue
@@ -62,6 +62,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </v-col>
       </v-row>
       <div
+        ref="toolbar"
         id="analysis-toolbar"
         class="d-flex align-center flex-wrap my-2 col-gap-2 row-gap-4"
       >
@@ -103,21 +104,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </v-defaults-provider>
       </div>
       <AnalysisTable
-        v-if="table && filteredTasks.length"
+        v-if="table"
         :tasks="filteredTasks"
         :timing-option="timingOption"
       />
       <BoxPlot
-        v-if="!table && filteredTasks.length"
+        v-else
         :tasks="filteredTasks"
         :timing-option="timingOption"
-        sort-input-teleport-target="#analysis-toolbar"
+        :sort-input-teleport-target="toolbar?.id"
       />
     </v-container>
   </div>
 </template>
 
 <script>
+import { ref } from 'vue'
 import {
   debounce,
   pick,
@@ -246,9 +248,13 @@ export default {
      */
     const table = useInitialOptions('table', { props, emit }, true)
 
+    /** @type {import('vue').Ref<HTMLElement>} template ref */
+    const toolbar = ref(null)
+
     return {
       tasksFilter,
-      table
+      table,
+      toolbar,
     }
   },
 

--- a/src/views/Table.vue
+++ b/src/views/Table.vue
@@ -45,6 +45,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           >
             <TableComponent
               :tasks="filteredTasks"
+              v-model:initial-options="dataTableOptions"
             />
           </v-container>
         </v-col>
@@ -60,6 +61,7 @@ import graphqlMixin from '@/mixins/graphql'
 import subscriptionComponentMixin from '@/mixins/subscriptionComponent'
 import {
   initialOptions,
+  updateInitialOptionsEvent,
   useInitialOptions
 } from '@/utils/initialOptions'
 import { matchNode } from '@/components/cylc/common/filter'
@@ -167,6 +169,8 @@ export default {
     }
   },
 
+  emits: [updateInitialOptionsEvent],
+
   props: {
     initialOptions,
   },
@@ -178,7 +182,14 @@ export default {
      */
     const tasksFilter = useInitialOptions('tasksFilter', { props, emit }, {})
 
+    /**
+     * The Vuetify data table options (sortBy, page etc).
+     * @type {import('vue').Ref<object>}
+     */
+    const dataTableOptions = useInitialOptions('dataTableOptions', { props, emit })
+
     return {
+      dataTableOptions,
       tasksFilter,
     }
   },

--- a/tests/e2e/specs/analysis.cy.js
+++ b/tests/e2e/specs/analysis.cy.js
@@ -293,7 +293,12 @@ describe('Filters and Options save state', () => {
     })
   })
 
-  describe('Filters save state', () => {
+  describe('State saving', () => {
+    beforeEach(() => {
+      cy.visit('/#/workspace/one')
+      addView('Table')
+    })
+
     it('remembers task name, platform and timings when switching between workflows', () => {
       cy.visit('/#/workspace/one')
       addView('Analysis')
@@ -338,6 +343,38 @@ describe('Filters and Options save state', () => {
         .get('.c-analysis table > tbody > tr')
         .should('have.length', 1)
         .should('be.visible')
+    })
+
+    it('remembers sorting & page options when switching between workflows', () => {
+      const sortedClass = 'v-data-table__th--sorted'
+      cy.get('.c-table th')
+        .contains('Platform')
+        .closest('th').as('platformCol')
+        .should('not.have.class', sortedClass)
+        .click()
+        .should('have.class', sortedClass)
+      cy.get('.c-table .v-data-table-footer__items-per-page .v-select')
+        .as('itemsPerPage')
+        .find('input')
+        .should('not.have.value', -1)
+        .get('@itemsPerPage')
+        .click()
+        .get('[role="listbox"] .v-list-item')
+        .contains('All')
+        .click()
+        // Wait for menu to close
+        .should('not.exist')
+        .get('@itemsPerPage').find('input')
+        .should('have.value', -1)
+      // Navigate away
+      cy.visit('/#/')
+        .get('.c-dashboard')
+      // Navigate back
+      cy.visit('/#/workspace/one')
+      cy.get('@platformCol')
+        .should('have.class', sortedClass)
+      cy.get('@itemsPerPage').find('input')
+        .should('have.value', -1)
     })
   })
 })

--- a/tests/e2e/specs/analysis.cy.js
+++ b/tests/e2e/specs/analysis.cy.js
@@ -292,19 +292,18 @@ describe('Filters and Options save state', () => {
         .should('be.visible')
     })
   })
+
   describe('Filters save state', () => {
     it('remembers task name, platform and timings when switching between workflows', () => {
       cy.visit('/#/workspace/one')
       addView('Analysis')
+
       // Check default options
       cy
         .get('.c-analysis table > tbody > tr')
         .should('have.length', numTasks)
         .should('be.visible')
-      cy
-        .get('td')
-        .contains('30')
-        .should('be.visible')
+
       // Set platform filter options
       cy
         .get('#c-analysis-filter-task-platforms')
@@ -313,10 +312,12 @@ describe('Filters and Options save state', () => {
         .get('.v-list-item')
         .contains('platform_1')
         .click({ force: true })
+
       // Set queue task name filter options
       cy
         .get('#c-analysis-filter-task-name')
         .type('wait')
+
       // Set task times filter options
       cy
         .get('#c-analysis-filter-task-timings')
@@ -325,27 +326,14 @@ describe('Filters and Options save state', () => {
         .get('.v-list-item')
         .contains('Queue')
         .click({ force: true })
+
       // Navigate away
       cy.visit('/#/')
       cy.get('.c-dashboard')
       // Navigate back
       cy.visit('/#/workspace/one')
-      // Check name filter
-      cy
-        .get('td')
-        .contains('waiting')
-        .should('be.visible')
-      // Check timing filter
-      cy
-        .get('td')
-        .contains('00:00:12')
-        .should('be.visible')
-      // Check platform filter
-      cy
-        .get('td')
-        .contains('platform_1')
-        .should('be.visible')
-      // Other checks
+
+      // Check number of tasks
       cy
         .get('.c-analysis table > tbody > tr')
         .should('have.length', 1)

--- a/tests/e2e/specs/analysis.cy.js
+++ b/tests/e2e/specs/analysis.cy.js
@@ -276,7 +276,7 @@ function addView (view) {
 describe('Filters and Options save state', () => {
   const numTasks = sortedTasks.length
   describe('Options save state', () => {
-    it.only('remembers table and box & whiskers toggle option when switching between workflows', () => {
+    it('remembers table and box & whiskers toggle option when switching between workflows', () => {
       cy.visit('/#/workspace/one')
       addView('Analysis')
       cy.get('.c-analysis [data-cy=box-plot-toggle]')

--- a/tests/e2e/specs/analysis.cy.js
+++ b/tests/e2e/specs/analysis.cy.js
@@ -265,3 +265,91 @@ describe('Analysis view', () => {
     })
   })
 })
+
+function addView (view) {
+  cy.get('[data-cy=add-view-btn]').click()
+  cy.get(`#toolbar-add-${view}-view`).click()
+    // wait for menu to close
+    .should('not.be.exist')
+}
+
+describe('Filters and Options save state', () => {
+  const numTasks = sortedTasks.length
+  describe('Options save state', () => {
+    it.only('remembers table and box & whiskers toggle option when switching between workflows', () => {
+      cy.visit('/#/workspace/one')
+      addView('Analysis')
+      cy.get('.c-analysis [data-cy=box-plot-toggle]')
+        .click()
+        .get('.vue-apexcharts')
+        .should('be.visible')
+      // Navigate away
+      cy.visit('/#/')
+      cy.get('.c-dashboard')
+      // Navigate back
+      cy.visit('/#/workspace/one')
+      cy.get('.vue-apexcharts')
+        .should('be.visible')
+    })
+  })
+  describe('Filters save state', () => {
+    it('remembers task name, platform and timings when switching between workflows', () => {
+      cy.visit('/#/workspace/one')
+      addView('Analysis')
+      // Check default options
+      cy
+        .get('.c-analysis table > tbody > tr')
+        .should('have.length', numTasks)
+        .should('be.visible')
+      cy
+        .get('td')
+        .contains('30')
+        .should('be.visible')
+      // Set platform filter options
+      cy
+        .get('#c-analysis-filter-task-platforms')
+        .click({ force: true })
+      cy
+        .get('.v-list-item')
+        .contains('platform_1')
+        .click({ force: true })
+      // Set queue task name filter options
+      cy
+        .get('#c-analysis-filter-task-name')
+        .type('wait')
+      // Set task times filter options
+      cy
+        .get('#c-analysis-filter-task-timings')
+        .click({ force: true })
+      cy
+        .get('.v-list-item')
+        .contains('Queue')
+        .click({ force: true })
+      // Navigate away
+      cy.visit('/#/')
+      cy.get('.c-dashboard')
+      // Navigate back
+      cy.visit('/#/workspace/one')
+      // Check name filter
+      cy
+        .get('td')
+        .contains('waiting')
+        .should('be.visible')
+      // Check timing filter
+      cy
+        .get('td')
+        .contains('00:00:12')
+        .should('be.visible')
+      // Check platform filter
+      cy
+        .get('td')
+        .contains('platform_1')
+        .should('be.visible')
+      // Other checks
+      cy
+        .get('.c-analysis table > tbody > tr')
+        .should('have.length', 1)
+        .should('be.visible')
+    })
+  })
+})

--- a/tests/e2e/specs/table.cy.js
+++ b/tests/e2e/specs/table.cy.js
@@ -132,10 +132,13 @@ function addView (view) {
     .should('not.be.exist')
 }
 
-describe('Filters save state', () => {
-  it('remembers job ID and file when switching between workflows', () => {
+describe('State saving', () => {
+  beforeEach(() => {
     cy.visit('/#/workspace/one')
     addView('Table')
+  })
+
+  it('remembers filters when switching between workflows', () => {
     cy.get('.c-treeitem:visible')
     cy
       .get('.c-table table > tbody > tr')
@@ -163,8 +166,6 @@ describe('Filters save state', () => {
     cy.get('.c-dashboard')
     // Navigate back
     cy.visit('/#/workspace/one')
-    cy.get('.c-gscan-workflow-name:first')
-      .click()
     cy
       .get('.c-table table > tbody > tr')
       .should('have.length', 1)
@@ -173,5 +174,37 @@ describe('Filters save state', () => {
       .get('td > div.d-flex > div')
       .contains('eventually')
       .should('be.visible')
+  })
+
+  it('remembers sorting & page options when switching between workflows', () => {
+    const sortedClass = 'v-data-table__th--sorted'
+    cy.get('.c-table th')
+      .contains('Platform')
+      .closest('th').as('platformCol')
+      .should('not.have.class', sortedClass)
+      .click()
+      .should('have.class', sortedClass)
+    cy.get('.c-table .v-data-table-footer__items-per-page .v-select')
+      .as('itemsPerPage')
+      .find('input')
+      .should('not.have.value', -1)
+      .get('@itemsPerPage')
+      .click()
+      .get('[role="listbox"] .v-list-item')
+      .contains('All')
+      .click()
+      // Wait for menu to close
+      .should('not.exist')
+      .get('@itemsPerPage').find('input')
+      .should('have.value', -1)
+    // Navigate away
+    cy.visit('/#/')
+      .get('.c-dashboard')
+    // Navigate back
+    cy.visit('/#/workspace/one')
+    cy.get('@platformCol')
+      .should('have.class', sortedClass)
+    cy.get('@itemsPerPage').find('input')
+      .should('have.value', -1)
   })
 })


### PR DESCRIPTION
Extends the solution for remembering sort and pagination to the Analysis view.
The Analysis view pr has not been merged in yet so its included in this - not sure if that's the right approach?

Addition to https://github.com/cylc/cylc-ui/pull/1751
Follow-up to https://github.com/cylc/cylc-ui/pull/1711
Partially addresses https://github.com/cylc/cylc-ui/issues/662

I think the Analysis E2E tests are now failing at `refreshes without getting bogus apexcharts error` putting a wait for a second at the beginning of the test fixes it but then get an eslint `Do not wait for arbitrary time periods`
 
<!-- Significant PRs should address an existing Issue. Choose one: -->
<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] No documentation update required.
